### PR TITLE
Setting proper binding in Laravel Service Provider

### DIFF
--- a/src/MailchimpServiceProvider.php
+++ b/src/MailchimpServiceProvider.php
@@ -26,7 +26,7 @@ class MailchimpServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind('Mailchimp', function ($app) {
+        $this->app->bind('Mailchimp\Mailchimp', function ($app) {
             $config = $app['config']['mailchimp'];
 
             return new Mailchimp($config['apikey']);


### PR DESCRIPTION
Laravel's service container has a specific format for bindings, which includes the namespace in the first argument of the `bind()` function. See the code snippet for more info: http://laravel.com/docs/5.1/container#binding

With this fix, I was able to properly use the service provider to inject the dependency.

The class where I was using the client has the following lines of code:
- `use Mailchimp\Mailchimp;`
- method where I want to inject the dependency: `public function myfunction(Mailchimp $mc)`
