### PR TITLE
Add Guzzle 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~5.0|~6.0",
         "illuminate/support": "~5.0"
     },
     "require-dev": {


### PR DESCRIPTION
We have a project that have a package with Guzzle 5 dependencie. While this package is Guzzle 6 only, we cannot use both package. So, by adding Guzzle 5 to this package, we'll be able to use both package and it would have take way much time to upgrade the other package to Guzzle 6 than update this one :)
